### PR TITLE
Update Main.lua

### DIFF
--- a/Portable/Main.lua
+++ b/Portable/Main.lua
@@ -379,7 +379,7 @@ function me:CreateUI_Buttons()
 		
 		-- The Secure Action Button
 		me.ui[button].sab = CreateFrame("Button", "PortableUIButton"..tostring(n).."SAB", me.ui[button], "SecureActionButtonTemplate")
-		me.ui[button].sab:RegisterForClicks("LeftButtonUp", "RightButtonUp")
+		me.ui[button].sab:RegisterForClicks("LeftButtonDown", "RightButtonDown")
 		me.ui[button].sab:SetScript("OnEnter", function(self, ...)
 				me:DoScript_OnEnter(self, ...)
 			end)


### PR DESCRIPTION
Spells casting on key release are now restricted to Drakthyr Evokers. Changed the RegisterForClicks to down to account for this.