### PR TITLE
Ensures the buttons work, regardless of the ActionButtonUseKeyDown console option

### DIFF
--- a/Portable/Main.lua
+++ b/Portable/Main.lua
@@ -364,8 +364,9 @@ function me:CreateUI_Buttons()
 			end)
 		
 		-- The Secure Action Button
-		me.ui[button].sab = CreateFrame("Button", "PortableUIButton"..tostring(n).."SAB", me.ui[button], "SecureActionButtonTemplate")
-		me.ui[button].sab:RegisterForClicks("LeftButtonUp", "RightButtonUp")
+		me.ui[button].sab = CreateFrame("Button", "PortableUIButton"..tostring(n).."SAB", me.ui[button], "InsecureActionButtonTemplate")
+		me.ui[button].sab:RegisterForClicks("LeftButtonDown", "RightButtonDown")
+		me.ui[button].sab:SetAttribute("pressAndHoldAction", "1") -- Ensures the action always fires on Down, regardless of the ActionButtonUseKeyDown cvar
 		me.ui[button].sab:SetScript("OnEnter", function(self, ...)
 				me:DoScript_OnEnter(self, ...)
 			end)
@@ -1168,9 +1169,8 @@ end
 
 -- Show the Configuration
 function me:Helper_ShowConfig()
-	--InterfaceAddOnsList_Update()	-- If the Blizzard Options Frame hasn't been Opened yet, OpenToCategory will fail, so we force a refresh first
-	InterfaceOptionsFrame_OpenToCategory(L["Frame Style  |c00000000Portable"])	-- By selecting a SubCategory first, the Options Tree will be open when we select the main Category
-	InterfaceOptionsFrame_OpenToCategory(myName)	-- Select the main category (which is setup as an About frame)
+	Settings.OpenToCategory(L["Frame Style  |c00000000Portable"])	-- By selecting a SubCategory first, the Options Tree will be open when we select the main Category
+	Settings.OpenToCategory(me:GetAddonInfo("Title"))	-- Select the main category (which is setup as an About frame)
 end
 
 -- Enable/Disable close with ESCape key

--- a/Portable/Options.lua
+++ b/Portable/Options.lua
@@ -12,7 +12,6 @@ local options = {
 		about = {
 			order = 0,	type = "group",	name = L["About"],
 			args = {
-				aboutdesc2 = {	order = 3,	type = "description",	name = "\n|cffc0c0c0"..L["ActionButtonUseKeyDown"].."|r\n",	fontSize = "large",	width = "full",	},
 				aboutdesc3 = {	order = 4,	type = "description",	name  = "\n|cffc0c0c0"..L["Version"].."|cff606060: |cffffff00"..me:GetAddonInfo("Version").."|r\n|cffc0c0c0"..L["Author"].."|cff606060: |cffffff00"..me:GetAddonInfo("Author").."|r\n",	fontSize = "medium",	width = "full",	},
 				aboutdesc4 = {	order = 5,	type = "description",	name = "|cffa0a0a0    "..me:GetAddonInfo("Notes"),	fontSize = "small",	width = "full",	},
 				aboutdesc5 = {	order = 6, type = "description", name = "\n\n\n\n|TInterface\\AddOns\\Portable\\Artwork\\PortableLogo.blp:160:160:0:0:512:512:0:256:256:512|t|TInterface\\AddOns\\Portable\\Artwork\\PortableLogo.blp:160:320:0:0:512:512:0:512:0:256|t|TInterface\\AddOns\\Portable\\Artwork\\PortableLogo.blp:160:160:0:0:512:512:256:512:256:512|t", width = "full", },


### PR DESCRIPTION
Additionally, `InsecureActionButtonTemplate` ensures the UI doesn't break if you enter combat, and `InterfaceOptionsFrame_OpenToCategory` no longer exists (`Settings.OpenToCategory` replaces it almost exactly)